### PR TITLE
feat: add KubeStellar Console to Kubernetes section

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 ## Kubernetes Icons Set (KIS)
 
 * [Kubernetes Icons Set](https://github.com/kubernetes/community/tree/master/icons) provides icons to standardize Kubernetes architecture diagrams for presentation. Having uniform architecture diagrams improve understandibility.
+- [KubeStellar Console](https://github.com/kubestellar/console) - Multi-cluster Kubernetes dashboard with AI-powered operations, real-time observability, and CNCF project integrations across edge and cloud clusters.
 
 ## Drawing Tools
 


### PR DESCRIPTION
[KubeStellar Console](https://github.com/kubestellar/console) is an open-source multi-cluster Kubernetes dashboard — CNCF Sandbox project with AI-powered operations, 20+ CNCF integrations (Argo, Kyverno, Istio, Prometheus), and real-time observability across edge and cloud.\n\n*Happy to adjust description or placement.*